### PR TITLE
fix missing mock initialization in test

### DIFF
--- a/use-cases/src/test/java/biz/paluch/clean/architecture/usecases/PlaceOrderImplTest.java
+++ b/use-cases/src/test/java/biz/paluch/clean/architecture/usecases/PlaceOrderImplTest.java
@@ -123,6 +123,8 @@ public class PlaceOrderImplTest {
     public void testPlaceOrderItemNotFound() throws Exception {
         List<String> items = Arrays.asList(ITEM_NAME_SCISSORS, ITEM_NAME_PAPER, ITEM_NAME_GLUE);
 
+        mockItemRepository();
+
         request.items = items;
         request.userName = USER_NAME_MARK;
         sut.placeOrder(request, orderOutput);


### PR DESCRIPTION
Add mock initialization in test PlaceOrderImplTest. testPlaceOrderItemNotFound()

The lack of this call generates a test failure when using Optional instead of returning null in ItemRepository find method. This can be seen in the fork https://github.com/euzebe/cleanarchitecture, master branch.